### PR TITLE
Update Python versions in Django workflow, delete directories

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Removed Python versions 3.8 and 3.9 from the workflow matrix. close #13 fixes #14 